### PR TITLE
Implement chart methods

### DIFF
--- a/deezer/client.py
+++ b/deezer/client.py
@@ -12,7 +12,7 @@ except ImportError:  # pragma: no cover - python 3
     from urllib.request import urlopen
 from deezer.resources import Album, Artist, Comment, Genre
 from deezer.resources import Playlist, Radio, Track, User
-from deezer.resources import Resource
+from deezer.resources import Chart, Resource
 
 
 class Client(object):
@@ -44,6 +44,7 @@ class Client(object):
         'search': None,
         'track': Track,
         'user': User,
+        'chart' : Chart
     }
 
     def __init__(self, **kwargs):
@@ -67,6 +68,19 @@ class Client(object):
         """
         if 'data' in item:
             return [self._process_json(i, parent) for i in item['data']]
+
+        if parent == "chart":
+            object_class = self.objects_types.get("chart")
+
+            return object_class(self, {
+                'type'  : parent,
+                'id'    : '0',
+                'tracks' : [self._process_json(i, None) for i in item['tracks']['data']],
+                'albums' : [self._process_json(i, None) for i in item['albums']['data']],
+                'artists' : [self._process_json(i, None) for i in item['artists']['data']],
+                'playlists' : [self._process_json(i, None) for i in item['playlists']['data']]
+            })
+
         result = {}
         for key, value in item.items():
             if isinstance(value, dict) and ('type' in value or 'data' in value):
@@ -140,21 +154,30 @@ class Client(object):
         jsn = json.loads(resp_str)
         return self._process_json(jsn, parent)
 
-    def get_album(self, object_id):
+    def get_chart(self, relation=None, **kwargs):
+        """
+        Get chart
+
+        :returns: a list of :class:`~deezer.resources.Resource` objects.
+        """
+        return self.get_object("chart", object_id='0', relation=relation,
+                               parent=None if relation else "chart", **kwargs)
+
+    def get_album(self, object_id, relation=None, **kwargs):
         """
         Get the album with the provided id
 
         :returns: an :class:`~deezer.resources.Album` object
         """
-        return self.get_object("album", object_id)
+        return self.get_object("album", object_id, relation=relation, **kwargs)
 
-    def get_artist(self, object_id):
+    def get_artist(self, object_id, relation=None, **kwargs):
         """
         Get the artist with the provided id
 
         :returns: an :class:`~deezer.resources.Artist` object
         """
-        return self.get_object("artist", object_id)
+        return self.get_object("artist", object_id, relation=relation, **kwargs)
 
     def get_comment(self, object_id):
         """

--- a/deezer/resources.py
+++ b/deezer/resources.py
@@ -218,3 +218,59 @@ class Radio(Resource):
         :returns: list of  :mod:`Track <deezer.resources.Track>` instances
         """
         return self.iter_relation('tracks', **kwargs)
+
+
+class Chart(Resource):
+    """To access charts."""
+
+    def get_tracks(self, **kwargs):
+        """
+        :returns: list of  :mod:`Track <deezer.resources.Track>` instances
+        """
+        return self.get_relation('tracks', **kwargs)
+
+    def iter_tracks(self, **kwargs):
+        """
+        Iterate tracks in the radio
+        :returns: list of  :mod:`Track <deezer.resources.Track>` instances
+        """
+        return self.iter_relation('tracks', **kwargs)
+
+    def get_albums(self, **kwargs):
+        """
+        :returns: the :mod:`Album <deezer.resources.Album>` instance
+        """
+        return self.get_relation('albums', **kwargs)
+
+    def iter_albums(self, **kwargs):
+        """
+        Iterate artist's albums.
+        :returns: list of :mod:`Album <deezer.resources.Album>` instances
+        """
+        return self.iter_relation('albums', **kwargs)
+
+    def get_artists(self, **kwargs):
+        """
+        :returns: list of :mod:`Artist <deezer.resources.Artist>` instances
+        """
+        return self.get_relation('artists', **kwargs)
+
+    def iter_artists(self, **kwargs):
+        """
+        Iterate artists for a genre.
+        :returns: list of :mod:`Artist <deezer.resources.Artist>` instances
+        """
+        return self.iter_relation('artists', **kwargs)
+
+    def get_playlists(self, **kwargs):
+        """
+        :returns: list of :mod:`Playlist <deezer.resources.Playlist>` instances
+        """
+        return self.get_relation('playlists', **kwargs)
+
+    def iter_playlists(self, **kwargs):
+        """
+        Iterate playlist for a genre.
+        :returns: list of :mod:`Playlist <deezer.resources.Playlist>` instances
+        """
+        return self.iter_relation('playlists', **kwargs)

--- a/deezer/tests/resources/chart/0/albums.json
+++ b/deezer/tests/resources/chart/0/albums.json
@@ -1,0 +1,31 @@
+{
+    "data": [{
+        "id": 14650244,
+        "title": "Where Is l'album de Gradur",
+        "cover": "https:\/\/api.deezer.com\/album\/14650244\/image",
+        "cover_small": "https:\/\/cdns-images.dzcdn.net\/images\/cover\/fd1700711d8891d1a481c30402553d7b\/56x56-000000-80-0-0.jpg",
+        "cover_medium": "https:\/\/cdns-images.dzcdn.net\/images\/cover\/fd1700711d8891d1a481c30402553d7b\/250x250-000000-80-0-0.jpg",
+        "cover_big": "https:\/\/cdns-images.dzcdn.net\/images\/cover\/fd1700711d8891d1a481c30402553d7b\/500x500-000000-80-0-0.jpg",
+        "cover_xl": "https:\/\/cdns-images.dzcdn.net\/images\/cover\/fd1700711d8891d1a481c30402553d7b\/1000x1000-000000-80-0-0.jpg",
+        "record_type": "album",
+        "tracklist": "https:\/\/api.deezer.com\/album\/14650244\/tracks",
+        "explicit_lyrics": true,
+        "position": 1,
+        "artist": {
+            "id": 5876247,
+            "name": "Gradur",
+            "link": "https:\/\/www.deezer.com\/artist\/5876247",
+            "picture": "https:\/\/api.deezer.com\/artist\/5876247\/image",
+            "picture_small": "https:\/\/cdns-images.dzcdn.net\/images\/artist\/45e6403e07e7deb4efcfe2943e3fb07f\/56x56-000000-80-0-0.jpg",
+            "picture_medium": "https:\/\/cdns-images.dzcdn.net\/images\/artist\/45e6403e07e7deb4efcfe2943e3fb07f\/250x250-000000-80-0-0.jpg",
+            "picture_big": "https:\/\/cdns-images.dzcdn.net\/images\/artist\/45e6403e07e7deb4efcfe2943e3fb07f\/500x500-000000-80-0-0.jpg",
+            "picture_xl": "https:\/\/cdns-images.dzcdn.net\/images\/artist\/45e6403e07e7deb4efcfe2943e3fb07f\/1000x1000-000000-80-0-0.jpg",
+            "radio": true,
+            "tracklist": "https:\/\/api.deezer.com\/artist\/5876247\/top?limit=50",
+            "type": "artist"
+        },
+        "type": "album"
+    }],
+    "total": 193,
+    "next": "https:\/\/api.deezer.com\/chart\/0\/albums?limit=1&index=1"
+}

--- a/deezer/tests/resources/chart/0/artists.json
+++ b/deezer/tests/resources/chart/0/artists.json
@@ -1,0 +1,18 @@
+{
+    "data": [{
+        "id": 1519461,
+        "name": "Pnl",
+        "link": "http://www.deezer.com/artist/1519461",
+        "picture": "http://api.deezer.com/artist/1519461/image",
+        "picture_small": "http://cdn-images.deezer.com/images/artist/c60478371435ba049949409706bb6673/56x56-000000-80-0-0.jpg",
+        "picture_medium": "http://cdn-images.deezer.com/images/artist/c60478371435ba049949409706bb6673/250x250-000000-80-0-0.jpg",
+        "picture_big": "http://cdn-images.deezer.com/images/artist/c60478371435ba049949409706bb6673/500x500-000000-80-0-0.jpg",
+        "picture_xl": "http://cdn-images.deezer.com/images/artist/c60478371435ba049949409706bb6673/1000x1000-000000-80-0-0.jpg",
+        "radio": true,
+        "tracklist": "http://api.deezer.com/artist/1519461/top?limit=50",
+        "position": 1,
+        "type": "artist"
+    }],
+    "total": 200,
+    "next": "http://api.deezer.com/chart/0/artists?limit=1&index=1"
+}

--- a/deezer/tests/resources/chart/0/noid.json
+++ b/deezer/tests/resources/chart/0/noid.json
@@ -1,0 +1,111 @@
+{
+  "tracks" : {
+    "data" : [
+      {
+        "id": "34671121",
+        "readable": true,
+        "title": "Billy Jean",
+        "link": "http://www.deezer.com/track/34671121",
+        "duration": "289",
+        "rank": "227054",
+        "explicit_lyrics": false,
+        "preview": "http://cdn-preview-1.deezer.com/stream/1e95a632ad4b40099feb3c26b2944bc9-0.mp3",
+        "artist": {
+          "id": "4263989",
+          "name": "Michael Jackson, Silver Pixel feat. Querubyna",
+          "link": "http://www.deezer.com/artist/4263989",
+          "picture": "https://api.deezer.com/artist/4263989/image",
+          "tracklist": "https://api.deezer.com/artist/4263989/top?limit=50",
+          "type": "artist"
+        },
+        "album": {
+          "id": "3356681",
+          "title": "Chill Out Connection Vol. 2",
+          "cover": "https://api.deezer.com/album/3356681/image",
+          "tracklist": "https://api.deezer.com/album/3356681/tracks",
+          "type": "album"
+        },
+        "type": "track"
+      }
+    ],
+    "total" : 1
+  },
+  "albums" : {
+    "data" : [
+      {
+        "id": "302127",
+        "title": "Discovery",
+        "upc": "724384960650",
+        "link": "http://www.deezer.com/album/302127",
+        "cover": "https://api.deezer.com/album/302127/image",
+        "genre_id": 113,
+        "genres": {
+          "data": [
+            {
+              "id": 113,
+              "name": "Dance",
+              "type": "genre"
+            }
+          ]
+        },
+        "label": "Parlophone France",
+        "nb_tracks": 14,
+        "duration": 3662,
+        "fans": 89849,
+        "rating": 0,
+        "release_date": "2001-03-07",
+        "available": true,
+        "artist": {
+          "id": "27",
+          "name": "Daft Punk",
+          "picture": "https://api.deezer.com/artist/27/image",
+          "type": "artist"
+        },
+        "type": "album"
+      }
+    ],
+    "total" : 1
+  },
+  "artists" : {
+    "data" : [
+      {
+        "id": 1519461,
+        "name": "Pnl",
+        "link": "http://www.deezer.com/artist/1519461",
+        "picture": "http://api.deezer.com/artist/1519461/image",
+        "picture_small": "http://cdn-images.deezer.com/images/artist/c60478371435ba049949409706bb6673/56x56-000000-80-0-0.jpg",
+        "picture_medium": "http://cdn-images.deezer.com/images/artist/c60478371435ba049949409706bb6673/250x250-000000-80-0-0.jpg",
+        "picture_big": "http://cdn-images.deezer.com/images/artist/c60478371435ba049949409706bb6673/500x500-000000-80-0-0.jpg",
+        "picture_xl": "http://cdn-images.deezer.com/images/artist/c60478371435ba049949409706bb6673/1000x1000-000000-80-0-0.jpg",
+        "radio": true,
+        "tracklist": "http://api.deezer.com/artist/1519461/top?limit=50",
+        "position": 1,
+        "type": "artist"
+      }
+    ],
+    "total" : 1
+  },
+  "playlists" : {
+    "data" : [
+      {
+        "id": "223",
+        "title": "M",
+        "description": "",
+        "duration": 438,
+        "public": true,
+        "is_loved_track": false,
+        "collaborative": false,
+        "rating": 0,
+        "link": "http://www.deezer.com/playlist/223",
+        "picture": "https://api.deezer.com/playlist/223/image",
+        "checksum": "369d45f162bb62e49cb1afdbae2725d8",
+        "creator": {
+          "id": "63",
+          "type": "user"
+        },
+        "type": "playlist"
+      }
+    ],
+    "total" : 1
+  }
+}

--- a/deezer/tests/resources/chart/0/playlists.json
+++ b/deezer/tests/resources/chart/0/playlists.json
@@ -1,0 +1,24 @@
+{
+    "data": [{
+        "id": 1109890291,
+        "title": "Top France",
+        "public": true,
+        "link": "http://www.deezer.com/playlist/1109890291",
+        "picture": "http://api.deezer.com/playlist/1109890291/image",
+        "picture_small": "http://cdn-images.deezer.com/images/playlist/32b79430a7811928a4aaddbf3298a245/56x56-000000-80-0-0.jpg",
+        "picture_medium": "http://cdn-images.deezer.com/images/playlist/32b79430a7811928a4aaddbf3298a245/250x250-000000-80-0-0.jpg",
+        "picture_big": "http://cdn-images.deezer.com/images/playlist/32b79430a7811928a4aaddbf3298a245/500x500-000000-80-0-0.jpg",
+        "picture_xl": "http://cdn-images.deezer.com/images/playlist/32b79430a7811928a4aaddbf3298a245/1000x1000-000000-80-0-0.jpg",
+        "tracklist": "http://api.deezer.com/playlist/1109890291/tracks",
+        "creation_date": "2015-01-08 11:45:11",
+        "user": {
+            "id": 637006841,
+            "name": "Deezer Charts",
+            "tracklist": "http://api.deezer.com/user/637006841/flow",
+            "type": "user"
+        },
+        "type": "playlist"
+    }],
+    "total": 145,
+    "next": "http://api.deezer.com/chart/0/playlists?limit=1&index=1"
+}

--- a/deezer/tests/resources/chart/0/tracks.json
+++ b/deezer/tests/resources/chart/0/tracks.json
@@ -1,0 +1,41 @@
+{
+  "data": [{
+    "id": 136889400,
+    "title": "Starboy",
+    "title_short": "Starboy",
+    "title_version": "",
+    "link": "https:\/\/www.deezer.com\/track\/136889400",
+    "duration": 230,
+    "rank": 970962,
+    "explicit_lyrics": true,
+    "preview": "http:\/\/cdn-preview-3.deezer.com\/stream\/3fb73bfa7a64760b5a7db5da76f068de-3.mp3",
+    "position": 1,
+    "artist": {
+      "id": 4050205,
+      "name": "The Weeknd",
+      "link": "https:\/\/www.deezer.com\/artist\/4050205",
+      "picture": "https:\/\/api.deezer.com\/artist\/4050205\/image",
+      "picture_small": "https:\/\/cdns-images.dzcdn.net\/images\/artist\/f7f0229f30d4455077fec80abba15583\/56x56-000000-80-0-0.jpg",
+      "picture_medium": "https:\/\/cdns-images.dzcdn.net\/images\/artist\/f7f0229f30d4455077fec80abba15583\/250x250-000000-80-0-0.jpg",
+      "picture_big": "https:\/\/cdns-images.dzcdn.net\/images\/artist\/f7f0229f30d4455077fec80abba15583\/500x500-000000-80-0-0.jpg",
+      "picture_xl": "https:\/\/cdns-images.dzcdn.net\/images\/artist\/f7f0229f30d4455077fec80abba15583\/1000x1000-000000-80-0-0.jpg",
+      "radio": true,
+      "tracklist": "https:\/\/api.deezer.com\/artist\/4050205\/top?limit=50",
+      "type": "artist"
+    },
+    "album": {
+      "id": 14652356,
+      "title": "Starboy",
+      "cover": "https:\/\/api.deezer.com\/album\/14652356\/image",
+      "cover_small": "https:\/\/cdns-images.dzcdn.net\/images\/cover\/afa915d88d871b6f929e61ada8aa644f\/56x56-000000-80-0-0.jpg",
+      "cover_medium": "https:\/\/cdns-images.dzcdn.net\/images\/cover\/afa915d88d871b6f929e61ada8aa644f\/250x250-000000-80-0-0.jpg",
+      "cover_big": "https:\/\/cdns-images.dzcdn.net\/images\/cover\/afa915d88d871b6f929e61ada8aa644f\/500x500-000000-80-0-0.jpg",
+      "cover_xl": "https:\/\/cdns-images.dzcdn.net\/images\/cover\/afa915d88d871b6f929e61ada8aa644f\/1000x1000-000000-80-0-0.jpg",
+      "tracklist": "https:\/\/api.deezer.com\/album\/14652356\/tracks",
+      "type": "album"
+    },
+    "type": "track"
+  }],
+  "total": 200,
+  "next": "https:\/\/api.deezer.com\/chart\/0\/tracks?limit=1&index=1"
+}

--- a/deezer/tests/test_client_parameter.py
+++ b/deezer/tests/test_client_parameter.py
@@ -52,6 +52,9 @@ class TestClient(unittest.TestCase):
         self.assertEqual(self.client.object_url("album", "12", "artist",
                          limit=1),
                          "https://api.deezer.com/album/12/artist?limit=1")
+        self.assertEqual(self.client.object_url("artist", "12", "albums",
+                         limit=1),
+                         "https://api.deezer.com/artist/12/albums?limit=1")
         self.assertRaises(TypeError, self.client.object_url, 'foo')
 
     def test_get_album(self):
@@ -121,6 +124,41 @@ class TestClient(unittest.TestCase):
         self.assertIsInstance(result, list)
         self.assertEqual(result[0].title, "Billy Jean")
         self.assertIsInstance(result[0], deezer.resources.Track)
+
+    def test_chart(self):
+        self.assertEqual(self.client.object_url("chart"),
+                         "https://api.deezer.com/chart")
+        result = self.client.get_chart()
+        self.assertIsInstance(result, deezer.resources.Chart)
+
+        self.assertIsInstance(result.tracks[0], deezer.resources.Track)
+        self.assertIsInstance(result.albums[0], deezer.resources.Album)
+        self.assertIsInstance(result.artists[0], deezer.resources.Artist)
+        self.assertIsInstance(result.playlists[0], deezer.resources.Playlist)
+
+    def test_chart_tracks(self):
+        result = self.client.get_chart("tracks")
+        self.assertIsInstance(result, list)
+        self.assertEqual(result[0].title, "Starboy")
+        self.assertIsInstance(result[0], deezer.resources.Track)
+
+    def test_chart_albums(self):
+        result = self.client.get_chart("albums")
+        self.assertIsInstance(result, list)
+        self.assertEqual(result[0].title, "Where Is l'album de Gradur")
+        self.assertIsInstance(result[0], deezer.resources.Album)
+
+    def test_chart_artists(self):
+        result = self.client.get_chart("artists")
+        self.assertIsInstance(result, list)
+        self.assertEqual(result[0].name, "Pnl")
+        self.assertIsInstance(result[0], deezer.resources.Artist)
+
+    def test_chart_playlists(self):
+        result = self.client.get_chart("playlists")
+        self.assertIsInstance(result, list)
+        self.assertEqual(result[0].title, "Top France")
+        self.assertIsInstance(result[0], deezer.resources.Playlist)
 
     def test_options(self):
         """Test a query with extra arguments"""

--- a/deezer/tests/test_resources.py
+++ b/deezer/tests/test_resources.py
@@ -199,3 +199,57 @@ class TestResources(unittest.TestCase):
         self.assertIsInstance(radio, deezer.resources.Radio)
         self.assertEqual(repr(radio), '<Radio: Techno/House>')
         self.assertEqual(type(genre.iter_radios()), GeneratorType)
+
+    def test_chart_tracks(self):
+        """
+        Test tracks method of chart resource
+        """
+        client = deezer.Client()
+        chart = client.get_chart()
+        tracks = chart.get_tracks()
+        self.assertIsInstance(tracks, list)
+        track = tracks[0]
+        self.assertIsInstance(track, deezer.resources.Track)
+        self.assertEqual(repr(track), '<Track: Starboy>')
+        self.assertEqual(type(chart.iter_tracks()), GeneratorType)
+
+    def test_chart_artists(self):
+        """
+        Test artists method of chart resource
+        """
+        client = deezer.Client()
+        chart = client.get_chart()
+        artists = chart.get_artists()
+        self.assertIsInstance(artists, list)
+        artist = artists[0]
+        self.assertIsInstance(artist, deezer.resources.Artist)
+        self.assertEqual(repr(artist), '<Artist: Pnl>')
+        self.assertEqual(type(chart.iter_artists()), GeneratorType)
+
+    def test_chart_albums(self):
+        """
+        Test albums method of chart resource
+        """
+        client = deezer.Client()
+        chart = client.get_chart()
+        albums = chart.get_albums()
+        self.assertIsInstance(albums, list)
+        album = albums[0]
+        self.assertIsInstance(album, deezer.resources.Album)
+        self.assertEqual(repr(album),
+                         "<Album: Where Is l'album de Gradur>")
+        self.assertEqual(type(chart.iter_albums()), GeneratorType)
+
+    def test_chart_playlists(self):
+        """
+        Test playlists method of chart resource
+        """
+        client = deezer.Client()
+        chart = client.get_chart()
+        playlists = chart.get_playlists()
+        self.assertIsInstance(playlists, list)
+        playlist = playlists[0]
+        self.assertIsInstance(playlist, deezer.resources.Playlist)
+        self.assertEqual(repr(playlist),
+                         "<Playlist: Top France>")
+        self.assertEqual(type(chart.iter_playlists()), GeneratorType)


### PR DESCRIPTION
I needed to use those methods which wasn't available in your module, so i did it.
BTW i'm a bit sorry about quality but this method is the only one to return array of different types and where relations are attached to a chart entity with id 0.
This time i deliver it directly with tests.