### PR TITLE
Made tornado an optional extra.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,8 @@ unreleased
 
 - Added index and limit to Client.search & Client.get_charts. Defaults are 
   set to deezer api defaults.
+- Moved tornado to an optional dependency. Install with pip install 
+  deezer-python[async]
 
 0.7.0 (2018-10-03)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,12 @@ The package is published on the `Python index <https://pypi.python.org/pypi/deez
 
     pip install deezer-python
 
+to have async support run the following:
+
+::
+
+   pip install deezer-python[async]
+
 And that's it!
 
 Basic Use

--- a/setup.py
+++ b/setup.py
@@ -26,13 +26,15 @@ setup(
     license='MIT',
     packages=['deezer'],
     install_requires=[
-        'tornado',
         'six',
         'requests',
     ],
     tests_require=[
         'requests-mock',
     ],
+    extras_require={
+        'async': ['tornado']
+    },
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,7 @@ changedir = docs/source
 deps =
     sphinx
     sphinx_rtd_theme
+    tornado
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
 


### PR DESCRIPTION
- [X] Updated documentation for new feature
- [X] Added an entry at the top of History.rst, under the unreleased section
 
The main difficulty was sphinx, i couldn't figure how to get it to see tornado (I attached the error below) so I made it an docs dependency and it went through fine.

```
docs runtests: commands[0] | sphinx-build -W -b html -d 'E:\projects\deezer-python\.tox\docs\tmp/doctrees' . 'E:\projects\deezer-python\.tox\docs\tmp/html'
Running Sphinx v1.8.1

Configuration error:
There is a programmable error in your configuration file:

Traceback (most recent call last):
  File "e:\projects\deezer-python\.tox\docs\lib\site-packages\sphinx\config.py", line 368, in eval_config_file
    execfile_(filename, namespace)
  File "e:\projects\deezer-python\.tox\docs\lib\site-packages\sphinx\util\pycompat.py", line 150, in execfile_
    exec_(code, _globals)
  File "E:\projects\deezer-python\docs\source\conf.py", line 60, in <module>
    import deezer
  File "E:\projects\deezer-python\deezer\__init__.py", line 7, in <module>
    from deezer.asynchronous import AsyncClient
  File "E:\projects\deezer-python\deezer\asynchronous.py", line 8, in <module>
    from tornado.gen import coroutine, Return
ModuleNotFoundError: No module named 'tornado'

ERROR: InvocationError for command 'E:\\projects\\deezer-python\\.tox\\docs\\Scripts\\sphinx-build.EXE -W -b html -d E:\\projects\\deezer-python\\.tox\\docs\\tmp/doctrees . E:\\projects\\deezer-python\\.tox\\docs\\tmp/html' (exited with code 2)
```

Fixes #19 