### PR TITLE
Python 3.7+ support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,6 @@ matrix:
       dist: xenial
     - python: pypy3
       env: TOXENV=pypy3
-  allow_failures:
-    - python: 3.7
-    - python: 3.8-dev
-    - python: pypy3
 
 install:
   - pip install codecov tox

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -95,7 +95,7 @@ following guidelines:
 
 1. It should include tests for feature or bug fixes.
 2. If it adds functionality, the docs should be updated.
-3. It should work for Python 3.4, 3.5, 3.6 and for PyPy3.
+3. It should work for Python 3.4, 3.5, 3.6, 3.7 and for PyPy3.
    Check `Travis`_ as well as `AppVeyor`_ and make sure that the tests
    pass for all supported Python versions.
 4. If your change is worthwhile a mention in the changelog, update the

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,7 @@ Unreleased (2019-02-13)
 -----------------------
 
 - Tests with ``vcr.py`` instead of ``requests_mock``.
+- Sopprt for Python 3.7 & 3.8 is finally offical.
 
 1.0.0 (2019-02-11)
 ------------------

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     tests_require=["requests-mock"],
     python_requires=">=3.4",
     classifiers=[
-        "Development Status :: 4 - Beta",
+        "Development Status :: 5 - Stable",
         "Intended Audience :: Developers",
         "Natural Language :: English",
         "License :: OSI Approved :: MIT License",
@@ -42,6 +42,8 @@ setup(
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3 :: Only",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],


### PR DESCRIPTION
Thanks to #43 the tests are now passing on Python 3.7+

- Remove Python 3.7 & 3.8 from allowed failures
- Update classifiers