### PR TITLE
Get method error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ returned by the API.
 
 ``` {.python}
 >>> client = deezer.Client()
->>> client.get_album(12).title
+>>> client.get_album(680407).title
 'Monkey Business'
 ```
 

--- a/deezer/client.py
+++ b/deezer/client.py
@@ -145,7 +145,10 @@ class Client:
         """
         url = self.object_url(object_t, object_id, relation, **kwargs)
         response = self.session.get(url)
-        return self._process_json(response.json(), parent)
+        json = response.json()
+        if "error" in json:
+            raise ValueError("Invalid API request for %s %s" % (object_t, object_id))
+        return self._process_json(json, parent)
 
     def get_chart(self, relation=None, index=0, limit=10, **kwargs):
         """

--- a/deezer/client.py
+++ b/deezer/client.py
@@ -7,7 +7,7 @@ from urllib.parse import urlencode
 
 from deezer.utils import SortedDict
 from deezer.resources import Album, Artist, Comment, Genre
-from deezer.resources import Chart, Resource
+from deezer.resources import Chart
 from deezer.resources import Playlist, Radio, Track, User
 
 
@@ -90,9 +90,9 @@ class Client:
             result[parent.type] = parent
 
         if "type" in result:
-            object_class = self.objects_types.get(result["type"], Resource)
+            object_class = self.objects_types[result["type"]]
         else:
-            object_class = self.objects_types.get(parent, Resource)
+            object_class = self.objects_types[parent]
         return object_class(self, result)
 
     @property
@@ -147,7 +147,9 @@ class Client:
         response = self.session.get(url)
         json = response.json()
         if "error" in json:
-            raise ValueError("Invalid API request for %s %s" % (object_t, object_id))
+            raise ValueError(
+                "API request return error for object: %s id: %s" % (object_t, object_id)
+            )
         return self._process_json(json, parent)
 
     def get_chart(self, relation=None, index=0, limit=10, **kwargs):

--- a/tests/cassettes/TestClient.test_no_album_raise.yaml
+++ b/tests/cassettes/TestClient.test_no_album_raise.yaml
@@ -1,0 +1,37 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - identity
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.22.0
+    method: GET
+    uri: https://api.deezer.com/album/-1
+  response:
+    body:
+      string: '{"error":{"type":"DataException","message":"no data","code":800}}'
+    headers:
+      Content-Length:
+      - '65'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 25 Sep 2019 21:04:30 GMT
+      P3P:
+      - policyref="/w3c/p3p.xml" CP="IDC DSP COR CURa ADMa OUR IND PHY ONL COM STA"
+      Server:
+      - Apache
+      Set-Cookie:
+      - dzr_uniq_id=dzr_uniq_id_fr761e7d6d903672585e283abeb2d0e942b3d9c4; expires=Mon,
+        23-Mar-2020 21:04:30 GMT; Max-Age=15552000; path=/; domain=.deezer.com; secure
+      X-Host:
+      - blm-web-49
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/TestClient.test_no_artist_raise.yaml
+++ b/tests/cassettes/TestClient.test_no_artist_raise.yaml
@@ -1,0 +1,37 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - identity
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.22.0
+    method: GET
+    uri: https://api.deezer.com/artist/-1
+  response:
+    body:
+      string: '{"error":{"type":"DataException","message":"no data","code":800}}'
+    headers:
+      Content-Length:
+      - '65'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 25 Sep 2019 21:04:30 GMT
+      P3P:
+      - policyref="/w3c/p3p.xml" CP="IDC DSP COR CURa ADMa OUR IND PHY ONL COM STA"
+      Server:
+      - Apache
+      Set-Cookie:
+      - dzr_uniq_id=dzr_uniq_id_fra50c22608ba89c514271f03f4a4c885f786f91; expires=Mon,
+        23-Mar-2020 21:04:30 GMT; Max-Age=15552000; path=/; domain=.deezer.com; secure
+      X-Host:
+      - blm-web-15
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/TestClient.test_no_comment_raise.yaml
+++ b/tests/cassettes/TestClient.test_no_comment_raise.yaml
@@ -1,0 +1,37 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - identity
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.22.0
+    method: GET
+    uri: https://api.deezer.com/comment/-1
+  response:
+    body:
+      string: '{"error":{"type":"DataException","message":"no data","code":800}}'
+    headers:
+      Content-Length:
+      - '65'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 25 Sep 2019 21:04:30 GMT
+      P3P:
+      - policyref="/w3c/p3p.xml" CP="IDC DSP COR CURa ADMa OUR IND PHY ONL COM STA"
+      Server:
+      - Apache
+      Set-Cookie:
+      - dzr_uniq_id=dzr_uniq_id_fr8e793244548adfbbf5254d6714292cdab32b82; expires=Mon,
+        23-Mar-2020 21:04:30 GMT; Max-Age=15552000; path=/; domain=.deezer.com; secure
+      X-Host:
+      - blm-web-121
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/TestClient.test_no_genre_raise.yaml
+++ b/tests/cassettes/TestClient.test_no_genre_raise.yaml
@@ -1,0 +1,39 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - identity
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.22.0
+    method: GET
+    uri: https://api.deezer.com/genre/-1
+  response:
+    body:
+      string: '{"error":{"type":"ParameterException","message":"Wrong parameter","code":500}}'
+    headers:
+      Content-Length:
+      - '78'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 25 Sep 2019 21:04:30 GMT
+      P3P:
+      - policyref="/w3c/p3p.xml" CP="IDC DSP COR CURa ADMa OUR IND PHY ONL COM STA"
+      Server:
+      - Apache
+      Set-Cookie:
+      - dzr_uniq_id=dzr_uniq_id_fr9bff60c8f2d435cf52f5787b759ec66b31db95; expires=Mon,
+        23-Mar-2020 21:04:30 GMT; Max-Age=15552000; path=/; domain=.deezer.com; secure
+      Vary:
+      - Accept-Encoding
+      X-Host:
+      - blm-web-107
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/TestClient.test_no_playlist_raise.yaml
+++ b/tests/cassettes/TestClient.test_no_playlist_raise.yaml
@@ -1,0 +1,37 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - identity
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.22.0
+    method: GET
+    uri: https://api.deezer.com/playlist/-1
+  response:
+    body:
+      string: '{"error":{"type":"DataException","message":"no data","code":800}}'
+    headers:
+      Content-Length:
+      - '65'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 25 Sep 2019 21:04:30 GMT
+      P3P:
+      - policyref="/w3c/p3p.xml" CP="IDC DSP COR CURa ADMa OUR IND PHY ONL COM STA"
+      Server:
+      - Apache
+      Set-Cookie:
+      - dzr_uniq_id=dzr_uniq_id_frf7420c4cdbc18d81be11c36dd3d145470a54e5; expires=Mon,
+        23-Mar-2020 21:04:30 GMT; Max-Age=15552000; path=/; domain=.deezer.com; secure
+      X-Host:
+      - blm-web-25
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/TestClient.test_no_radio_raise.yaml
+++ b/tests/cassettes/TestClient.test_no_radio_raise.yaml
@@ -1,0 +1,39 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - identity
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.22.0
+    method: GET
+    uri: https://api.deezer.com/radio/-1
+  response:
+    body:
+      string: '{"error":{"type":"ParameterException","message":"Wrong parameter","code":500}}'
+    headers:
+      Content-Length:
+      - '78'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 25 Sep 2019 21:04:30 GMT
+      P3P:
+      - policyref="/w3c/p3p.xml" CP="IDC DSP COR CURa ADMa OUR IND PHY ONL COM STA"
+      Server:
+      - Apache
+      Set-Cookie:
+      - dzr_uniq_id=dzr_uniq_id_fr0aced95862b3fb5db16f49c7639d7b73907eaf; expires=Mon,
+        23-Mar-2020 21:04:30 GMT; Max-Age=15552000; path=/; domain=.deezer.com; secure
+      Vary:
+      - Accept-Encoding
+      X-Host:
+      - blm-web-10
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/TestClient.test_no_track_raise.yaml
+++ b/tests/cassettes/TestClient.test_no_track_raise.yaml
@@ -1,0 +1,37 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - identity
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.22.0
+    method: GET
+    uri: https://api.deezer.com/track/-1
+  response:
+    body:
+      string: '{"error":{"type":"DataException","message":"no data","code":800}}'
+    headers:
+      Content-Length:
+      - '65'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 25 Sep 2019 21:04:30 GMT
+      P3P:
+      - policyref="/w3c/p3p.xml" CP="IDC DSP COR CURa ADMa OUR IND PHY ONL COM STA"
+      Server:
+      - Apache
+      Set-Cookie:
+      - dzr_uniq_id=dzr_uniq_id_fr01907354058fa9c07a8c76911d7bad87bcc54a; expires=Mon,
+        23-Mar-2020 21:04:30 GMT; Max-Age=15552000; path=/; domain=.deezer.com; secure
+      X-Host:
+      - blm-web-110
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/TestClient.test_no_user_raise.yaml
+++ b/tests/cassettes/TestClient.test_no_user_raise.yaml
@@ -1,0 +1,37 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - identity
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.22.0
+    method: GET
+    uri: https://api.deezer.com/user/-1
+  response:
+    body:
+      string: '{"error":{"type":"DataException","message":"no data","code":800}}'
+    headers:
+      Content-Length:
+      - '65'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 25 Sep 2019 21:04:30 GMT
+      P3P:
+      - policyref="/w3c/p3p.xml" CP="IDC DSP COR CURa ADMa OUR IND PHY ONL COM STA"
+      Server:
+      - Apache
+      Set-Cookie:
+      - dzr_uniq_id=dzr_uniq_id_frb04041173ecc934112f2f6e26fb124dd0ca08c; expires=Mon,
+        23-Mar-2020 21:04:30 GMT; Max-Age=15552000; path=/; domain=.deezer.com; secure
+      X-Host:
+      - blm-web-149
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_client_parameter.py
+++ b/tests/test_client_parameter.py
@@ -1,3 +1,4 @@
+import pytest
 import deezer
 from .base import BaseTestCaseWithVcr
 
@@ -67,20 +68,40 @@ class TestClient(BaseTestCaseWithVcr):
         album = self.client.get_album(302127)
         self.assertIsInstance(album, deezer.resources.Album)
 
+    def test_no_album_raise(self):
+        """Test method get_album for invalid value"""
+        with pytest.raises(ValueError):
+            self.client.get_album(-1)
+
     def test_get_artist(self):
         """Test methods to get an artist"""
         artist = self.client.get_artist(27)
         self.assertIsInstance(artist, deezer.resources.Artist)
+
+    def test_no_artist_raise(self):
+        """Test method get_artist for invalid value"""
+        with pytest.raises(ValueError):
+            self.client.get_artist(-1)
 
     def test_get_comment(self):
         """Test methods to get a comment"""
         comment = self.client.get_comment(2772704)
         self.assertIsInstance(comment, deezer.resources.Comment)
 
+    def test_no_comment_raise(self):
+        """Test method get_comment for invalid value"""
+        with pytest.raises(ValueError):
+            self.client.get_comment(-1)
+
     def test_get_genre(self):
         """Test methods to get a genre"""
         genre = self.client.get_genre(106)
         self.assertIsInstance(genre, deezer.resources.Genre)
+
+    def test_no_genre_raise(self):
+        """Test method get_genre for invalid value"""
+        with pytest.raises(ValueError):
+            self.client.get_genre(-1)
 
     def test_get_genres(self):
         """Test methods to get several genres"""
@@ -93,10 +114,20 @@ class TestClient(BaseTestCaseWithVcr):
         playlist = self.client.get_playlist(908622995)
         self.assertIsInstance(playlist, deezer.resources.Playlist)
 
+    def test_no_playlist_raise(self):
+        """Test method get_playlist for invalid value"""
+        with pytest.raises(ValueError):
+            self.client.get_playlist(-1)
+
     def test_get_radio(self):
         """Test methods to get a radio"""
         radio = self.client.get_radio(23261)
         self.assertIsInstance(radio, deezer.resources.Radio)
+
+    def test_no_radio_raise(self):
+        """Test method get_radio for invalid value"""
+        with pytest.raises(ValueError):
+            self.client.get_radio(-1)
 
     def test_get_radios(self):
         """Test methods to get a radios"""
@@ -109,10 +140,20 @@ class TestClient(BaseTestCaseWithVcr):
         track = self.client.get_track(3135556)
         self.assertIsInstance(track, deezer.resources.Track)
 
+    def test_no_track_raise(self):
+        """Test method get_track for invalid value"""
+        with pytest.raises(ValueError):
+            self.client.get_track(-1)
+
     def test_get_user(self):
         """Test methods to get a user"""
         user = self.client.get_user(359622)
         self.assertIsInstance(user, deezer.resources.User)
+
+    def test_no_user_raise(self):
+        """Test method get_user for invalid value"""
+        with pytest.raises(ValueError):
+            self.client.get_user(-1)
 
     def test_chart(self):
         self.assertEqual(


### PR DESCRIPTION
This modifif the get_object function in client to handle error for invalid value pass to the API request.
This fix issue #59, that call for an id that does not longer exist. I updated the README to use the actual id for the same album. However, this can break if the album id are changed, which is something we do not have control over.

There is now test that verify that invalid value passed to the method accepting id failed for unexisting id. I use id=-1 as testing value.

- [x] Include tests for bug fix and new functionality
- [ ] Updated documentation for new feature
- [ ] Added an entry at the top of HISTORY.rst, under the unreleased section

Fixes #59 