### PR TITLE
Fix Appveyor build

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,7 @@ build: off
 
 install:
   # Install tox to run tests
+  - pip install -U pip
   - pip install tox
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,26 +1,13 @@
 environment:
-
   matrix:
-
-    - PYTHON: "C:\\Python35-x64"
-      TOXENV: py35
-
-    - PYTHON: "C:\\Python36-x64"
-      TOXENV: py36
-
-    - PYTHON: "C:\\Python37-x64"
-      TOXENV: py37
-
-init:
-  - SET "PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  - TOXENV: py35
+  - TOXENV: py36
+  - TOXENV: py37
 
 build: off
 
 install:
-  # Install tox to run tests
-  - pip install -U pip
-  - pip install tox
+- pip install tox
 
 test_script:
-  # Run the project tests
-  - tox
+- tox


### PR DESCRIPTION
Looks like Bandit doesn't install very well on Appveyor under Python 3.5:

```
/ff2f2c8f1f0ca1569f678eeb608c0f973b835985410985594fbee96be820/bandit-1.6.2-py2.py3-none-any.whl (122kB)
Exception:
Traceback (most recent call last):
  File "C:\projects\deezer-python\.tox\py35\lib\site-packages\pip\_vendor\pkg_resources\__init__.py", line 2851, in _dep_map
    return self.__dep_map
  File "C:\projects\deezer-python\.tox\py35\lib\site-packages\pip\_vendor\pkg_resources\__init__.py", line 2685, in __getattr__
    raise AttributeError(attr)
AttributeError: _DistInfoDistribution__dep_map
```