### PR TITLE
fix: typos and types

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@
   <img src="https://img.shields.io/pypi/pyversions/deezer-python.svg?style=flat-square" alt="pyversions">
   <img src="https://img.shields.io/pypi/l/deezer-python.svg?style=flat-square" alt="license">
   <a href="https://github.com/browniebroke/deezer-python">
-    <img src="https://tokei.rs/b1/github/browniebroke/deezer-python/" alt="LoC">
+    <img src="https://tokei.rs/b1/github/browniebroke/deezer-python" alt="LoC">
   </a>
 </p>
 
-A friendly Python wrapper around the [Deezer API](http://developers.deezer.com/api).
+A friendly Python wrapper around the [Deezer API](https://developers.deezer.com/api).
 
 ## Installation
 

--- a/src/deezer/resources.py
+++ b/src/deezer/resources.py
@@ -229,23 +229,21 @@ class Genre(Resource):
     picture_big: str
     picture_xl: str
 
-    def get_artists(self, **kwargs) -> PaginatedList[Artist]:
+    def get_artists(self, **kwargs) -> list[Artist]:
         """
         Get all artists for a genre.
 
-        :returns: a :class:`PaginatedList <deezer.pagination.PaginatedList>`
-                  of :class:`Artist <deezer.resources.Artist>` instances.
+        :returns: list of :class:`Artist <deezer.resources.Artist>` instances
         """
-        return self.get_paginated_list("artists", **kwargs)
+        return self.get_relation("artists", **kwargs)
 
-    def get_radios(self, **kwargs) -> PaginatedList[Radio]:
+    def get_radios(self, **kwargs) -> list[Radio]:
         """
         Get all radios for a genre.
 
-        :returns: a :class:`PaginatedList <deezer.pagination.PaginatedList>`
-                  of :class:`Radio <deezer.resources.Radio>` instances
+        :returns: list of :class:`Radio <deezer.resources.Radio>` instances
         """
-        return self.get_paginated_list("radios", **kwargs)
+        return self.get_relation("radios", **kwargs)
 
 
 class Track(Resource):

--- a/src/deezer/resources.py
+++ b/src/deezer/resources.py
@@ -121,6 +121,7 @@ class Album(Resource):
     contributors: list[Artist]
 
     artist: Artist
+    tracks: list[Track]
 
     _parse_release_date = staticmethod(parse_date)
 
@@ -194,8 +195,10 @@ class Artist(Resource):
         """
         return self.get_paginated_list("related", **kwargs)
 
-    def get_radio(self, **kwargs) -> PaginatedList[Radio]:
+    def get_radio(self, **kwargs) -> list[Track]:
         """
+        Get a list of tracks.
+
         :returns: list of :class:`Track <deezer.resources.Track>` instances
         """
         return self.get_relation("radio", **kwargs)
@@ -295,6 +298,8 @@ class Track(Resource):
 
     def get_album(self) -> Album:
         """
+        Get the album of the Track.
+
         :returns: the :class:`Album <deezer.resources.Album>` instance
         """
         return self.client.get_album(self.album.id)
@@ -397,6 +402,7 @@ class Playlist(Resource):
     picture_xl: str
     checksum: str
     creator: User
+    tracks: list[Track]
 
     def get_tracks(self, **kwargs) -> PaginatedList[Track]:
         """

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -154,14 +154,14 @@ class TestGenre:
 
     def test_get_artists(self, electro):
         artists = electro.get_artists()
-        assert isinstance(artists, deezer.pagination.PaginatedList)
+        assert isinstance(artists, list)
         artist = artists[0]
         assert isinstance(artist, deezer.resources.Artist)
         assert repr(artist) == "<Artist: Major Lazer>"
 
     def test_get_radios(self, electro):
         radios = electro.get_radios()
-        assert isinstance(radios, deezer.pagination.PaginatedList)
+        assert isinstance(radios, list)
         radio = radios[0]
         assert isinstance(radio, deezer.resources.Radio)
         assert repr(radio) == "<Radio: Electro Swing>"


### PR DESCRIPTION
- [x] Include tests for bug fix and new functionality
- [x] Updated documentation for new feature

Fixes some typos and type hints.

**About ee90ff80347a9fe3a34d428ff7818d3f78e6c75d:**
According to the [Deezer documentation](https://developers.deezer.com/api/genre#connections), `genre / artists` and `genre / radios` return an object (and not a paginated list).  
Currently, [`Genre.get_artists`](https://github.com/browniebroke/deezer-python/blob/4387822f6317a8fb92f4f055173a8c9cb7c0b59a/src/deezer/resources.py#L229-L236) and [`Genre.get_radios`](https://github.com/browniebroke/deezer-python/blob/4387822f6317a8fb92f4f055173a8c9cb7c0b59a/src/deezer/resources.py#L238-L245) return a `PaginatedList`. This causes a `KeyError: 'total'` when calling `len()` or getting the  `total` attribute from the returned object.