### PR TITLE
Test and fix paginated list

### DIFF
--- a/src/deezer/client.py
+++ b/src/deezer/client.py
@@ -283,14 +283,13 @@ class Client:
         """
         return self.request("GET", f"genre/{genre_id}")
 
-    def list_genres(self) -> PaginatedList[Genre]:
+    def list_genres(self) -> list[Genre]:
         """
         List musical genres.
 
-        :returns: a :class:`~deezer.pagination.PaginatedList`
-                  of :class:`~deezer.resources.Genre` objects.
+        :return: a list of :class:`~deezer.resources.Genre` instances
         """
-        return self._get_paginated_list("genre")
+        return self.request("GET", "genre")
 
     def get_playlist(self, playlist_id: int) -> Playlist:
         """

--- a/src/deezer/client.py
+++ b/src/deezer/client.py
@@ -315,14 +315,13 @@ class Client:
         """
         return self.request("GET", f"radio/{radio_id}")
 
-    def list_radios(self) -> PaginatedList[Radio]:
+    def list_radios(self) -> list[Radio]:
         """
         List radios.
 
-        :returns: a :class:`~deezer.pagination.PaginatedList`
-                  of :class:`~deezer.resources.Radio` objects.
+        :return: a list of :class:`~deezer.resources.Radio` instances
         """
-        return self._get_paginated_list("radio")
+        return self.request("GET", "radio")
 
     def get_radios_top(self) -> PaginatedList[Radio]:
         """

--- a/src/deezer/client.py
+++ b/src/deezer/client.py
@@ -351,7 +351,7 @@ class Client:
         user_id_str = str(user_id) if user_id else "me"
         return self.request("GET", f"user/{user_id_str}")
 
-    def get_user_albums(self, user_id: int | None = None) -> PaginatedList:
+    def get_user_albums(self, user_id: int | None = None) -> PaginatedList[Album]:
         """
         Get the favourites albums for the given user_id if provided or current user if not.
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -61,30 +61,35 @@ class TestClient:
     def test_tracks_chart(self, client):
         result = client.get_tracks_chart()
         assert isinstance(result, list)
+        assert len(result) == 10
         assert result[0].title == "Khapta"
         assert isinstance(result[0], deezer.resources.Track)
 
     def test_albums_chart(self, client):
         result = client.get_albums_chart()
         assert isinstance(result, list)
+        assert len(result) == 10
         assert result[0].title == "Lacrim"
         assert isinstance(result[0], deezer.resources.Album)
 
     def test_artists_chart(self, client):
         result = client.get_artists_chart()
         assert isinstance(result, list)
+        assert len(result) == 10
         assert result[0].name == "Lacrim"
         assert isinstance(result[0], deezer.resources.Artist)
 
     def test_playlists_chart(self, client):
         result = client.get_playlists_chart()
         assert isinstance(result, list)
+        assert len(result) == 10
         assert result[0].title == "Les titres du moment"
         assert isinstance(result[0], deezer.resources.Playlist)
 
     def test_podcasts_chart(self, client):
         result = client.get_podcasts_chart()
         assert isinstance(result, list)
+        assert len(result) == 10
         assert result[0].title == "Rob Beckett and Josh Widdicombe's Parenting Hell"
         assert isinstance(result[0], deezer.resources.Podcast)
 
@@ -103,6 +108,7 @@ class TestClient:
         editorials = client.list_editorials()
         assert isinstance(editorials, deezer.pagination.PaginatedList)
         assert isinstance(editorials[0], deezer.resources.Editorial)
+        assert len(editorials) == 26
 
     def test_get_episode(self, client):
         """Test methods to get an episode"""
@@ -128,6 +134,7 @@ class TestClient:
         """Test methods to list several genres"""
         genres = client.list_genres()
         assert isinstance(genres, deezer.pagination.PaginatedList)
+        assert len(genres) == 23
         assert isinstance(genres[0], deezer.resources.Genre)
 
     def test_get_playlist(self, client):
@@ -164,12 +171,14 @@ class TestClient:
         """Test methods to list radios"""
         radios = client.list_radios()
         assert isinstance(radios, deezer.pagination.PaginatedList)
+        assert len(radios) == 115
         assert isinstance(radios[0], deezer.resources.Radio)
 
     def test_get_radios_top(self, client):
         radios = client.get_radios_top()
         assert isinstance(radios, deezer.pagination.PaginatedList)
         assert isinstance(radios[0], deezer.resources.Radio)
+        assert len(radios) == 78
 
     def test_get_track(self, client):
         """Test methods to get a track"""
@@ -290,6 +299,7 @@ class TestClient:
         first = result[0]
         assert isinstance(first, deezer.Track)
         assert first.title == "Soliloquy"
+        assert len(result) == 298
 
     def test_search_strict(self, client):
         result = client.search("Soliloquy", strict=True)
@@ -297,6 +307,7 @@ class TestClient:
         first = result[0]
         assert isinstance(first, deezer.Track)
         assert first.title == "Soliloquy"
+        assert len(result) == 298
 
     @pytest.mark.parametrize(
         "ordering",
@@ -320,18 +331,21 @@ class TestClient:
         first = result[0]
         assert isinstance(first, deezer.Track)
         assert first.title == "Soliloquy"
+        assert len(result) == 298
 
     def test_search_advanced_simple(self, client):
         """Test advanced search with one term"""
         result = client.search(artist="Lou Doillon")
         assert isinstance(result, deezer.PaginatedList)
         assert result[0].title == "Too much"
+        assert len(result) == 163
 
     def test_search_advanced_multiple(self, client):
         """Test advanced search with two term"""
         result = client.search(artist="Lou Doillon", album="Lay Low")
         assert isinstance(result, deezer.PaginatedList)
         assert result[0].title == "Where To Start"
+        assert len(result) == 22
 
     def test_search_albums(self, client):
         """Test search for albums"""
@@ -340,6 +354,7 @@ class TestClient:
         first = result[0]
         assert isinstance(first, deezer.resources.Album)
         assert first.title == "Discovery"
+        assert len(result) == 295
 
     def test_search_artists(self, client):
         """Test search for artists"""
@@ -348,6 +363,7 @@ class TestClient:
         first = result[0]
         assert isinstance(first, deezer.resources.Artist)
         assert first.name == "Daft Punk"
+        assert len(result) == 5
 
     @pytest.mark.parametrize(
         ("header_value", "expected_name"),

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -170,7 +170,7 @@ class TestClient:
     def test_list_radios(self, client):
         """Test methods to list radios"""
         radios = client.list_radios()
-        assert isinstance(radios, deezer.pagination.PaginatedList)
+        assert isinstance(radios, list)
         assert len(radios) == 115
         assert isinstance(radios[0], deezer.resources.Radio)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -133,7 +133,7 @@ class TestClient:
     def test_list_genres(self, client):
         """Test methods to list several genres"""
         genres = client.list_genres()
-        assert isinstance(genres, deezer.pagination.PaginatedList)
+        assert isinstance(genres, list)
         assert len(genres) == 23
         assert isinstance(genres[0], deezer.resources.Genre)
 

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -35,6 +35,7 @@ class TestAlbum:
         track = tracks[0]
         assert isinstance(track, deezer.resources.Track)
         assert repr(track) == "<Track: One More Time>"
+        assert len(tracks) == 14
 
     def test_contributors(self, client):
         album = client.get_album(302128)
@@ -73,6 +74,7 @@ class TestArtist:
         album = albums[0]
         assert isinstance(album, deezer.resources.Album)
         assert repr(album) == "<Album: Random Access Memories>"
+        assert len(albums) == 32
 
     def test_get_top(self, daft_punk):
         tracks = daft_punk.get_top()
@@ -80,10 +82,12 @@ class TestArtist:
         track = tracks[0]
         assert isinstance(track, deezer.resources.Track)
         assert repr(track) == "<Track: Instant Crush>"
+        assert len(tracks) == 100
 
     def test_get_radio(self, daft_punk):
         tracks = daft_punk.get_radio()
         assert isinstance(tracks, list)
+        assert len(tracks) == 25
         track = tracks[0]
         assert isinstance(track, deezer.resources.Track)
         assert repr(track) == "<Track: One More Time>"
@@ -94,6 +98,7 @@ class TestArtist:
         related_artist = related_artists[0]
         assert isinstance(related_artist, deezer.resources.Artist)
         assert repr(related_artist) == "<Artist: Justice>"
+        assert len(related_artists) == 39
 
 
 class TestTrack:
@@ -134,6 +139,7 @@ class TestRadio:
     def test_get_tracks(self, radio):
         tracks = radio.get_tracks()
         assert isinstance(tracks, list)
+        assert len(tracks) == 25
         track = tracks[0]
         assert isinstance(track, deezer.resources.Track)
         assert (
@@ -155,6 +161,7 @@ class TestGenre:
     def test_get_artists(self, electro):
         artists = electro.get_artists()
         assert isinstance(artists, list)
+        assert len(artists) == 48
         artist = artists[0]
         assert isinstance(artist, deezer.resources.Artist)
         assert repr(artist) == "<Artist: Major Lazer>"
@@ -162,6 +169,7 @@ class TestGenre:
     def test_get_radios(self, electro):
         radios = electro.get_radios()
         assert isinstance(radios, list)
+        assert len(radios) == 32
         radio = radios[0]
         assert isinstance(radio, deezer.resources.Radio)
         assert repr(radio) == "<Radio: Electro Swing>"
@@ -178,6 +186,7 @@ class TestChart:
         track = tracks[0]
         assert isinstance(track, deezer.resources.Track)
         assert repr(track) == "<Track: Bad Habits>"
+        assert len(tracks) == 10
 
     def test_get_artists(self, chart):
         artists = chart.get_artists()
@@ -185,6 +194,7 @@ class TestChart:
         artist = artists[0]
         assert isinstance(artist, deezer.resources.Artist)
         assert repr(artist) == "<Artist: Kanye West>"
+        assert len(artists) == 10
 
     def test_get_albums(self, chart):
         albums = chart.get_albums()
@@ -192,6 +202,7 @@ class TestChart:
         album = albums[0]
         assert isinstance(album, deezer.resources.Album)
         assert repr(album) == "<Album: Music Of The Spheres>"
+        assert len(albums) == 10
 
     def test_get_playlists(self, chart):
         playlists = chart.get_playlists()
@@ -199,6 +210,7 @@ class TestChart:
         playlist = playlists[0]
         assert isinstance(playlist, deezer.resources.Playlist)
         assert repr(playlist) == "<Playlist: Brand New UK>"
+        assert len(playlists) == 10
 
 
 class TestUser:
@@ -212,6 +224,7 @@ class TestUser:
         album = albums[0]
         assert isinstance(album, deezer.resources.Album)
         assert repr(album) == "<Album: A Century Of Movie Soundtracks Vol. 2>"
+        assert len(albums) == 7
 
     def test_get_artists(self, user):
         artists = user.get_artists()
@@ -219,6 +232,7 @@ class TestUser:
         artist = artists[0]
         assert isinstance(artist, deezer.resources.Artist)
         assert repr(artist) == "<Artist: Wax Tailor>"
+        assert len(artists) == 7
 
     def test_get_playlists(self, user):
         playlists = user.get_playlists()
@@ -226,6 +240,7 @@ class TestUser:
         playlist = playlists[0]
         assert isinstance(playlist, deezer.resources.Playlist)
         assert repr(playlist) == "<Playlist: AC/DC>"
+        assert len(playlists) == 25
 
     def test_get_tracks(self, user):
         tracks = user.get_tracks()
@@ -233,6 +248,7 @@ class TestUser:
         track = tracks[0]
         assert isinstance(track, deezer.resources.Track)
         assert repr(track) == "<Track: Poney Pt. I>"
+        assert len(tracks) == 3
 
 
 class TestPlaylist:
@@ -249,6 +265,7 @@ class TestPlaylist:
         first_track = tracks[0]
         assert isinstance(first_track, deezer.resources.Track)
         assert first_track.title == "Otherwise"
+        assert len(tracks) == 102
 
     def test_get_fans(self, playlist):
         fans = playlist.get_fans()
@@ -256,6 +273,7 @@ class TestPlaylist:
         first_fan = fans[0]
         assert isinstance(first_fan, deezer.resources.User)
         assert first_fan.name == "Fay22"
+        assert len(fans) == 100
 
 
 class TestPodcast:
@@ -297,6 +315,7 @@ class TestEditorial:
     def test_get_selection(self, editorial):
         albums = editorial.get_selection()
         assert isinstance(albums, list)
+        assert len(albums) == 10
         album = albums[0]
         assert isinstance(album, deezer.resources.Album)
         assert album.title == "Terre Promise"
@@ -316,3 +335,4 @@ class TestEditorial:
         album = albums[0]
         assert isinstance(album, deezer.resources.Album)
         assert repr(album) == "<Album: Girls>"
+        assert len(albums) == 199


### PR DESCRIPTION
- [x] Include tests for bug fix and new functionality
- [x] Updated documentation for new feature

- Added tests to check the length of each `list` / `PaginatedList`. These will also catch `list` wrongfully parsed as `PaginatedList` (see [this comment](https://github.com/browniebroke/deezer-python/pull/443#issuecomment-1024486487) for context).
- Fixed `Client.list_genres` and `Client.list_radios` methods that should return a `list` instead of a `PaginatedList` (see [1](https://developers.deezer.com/api/explorer?url=genre) and [2](https://developers.deezer.com/api/explorer?url=radio)).