### PR TITLE
ci: officially support Python 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12-dev"
         os:
           - ubuntu-latest
           - windows-latest


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos