### PR TITLE
chore: add fund to list of labels

### DIFF
--- a/.github/labels.toml
+++ b/.github/labels.toml
@@ -92,3 +92,8 @@ description = "Automatically closes as answered after a delay"
 color = "5f7972"
 name = "waiting"
 description = "Automatically closes if no answer after a delay"
+
+[fund]
+color = "0E8A16"
+name = "fund"
+description = "Add a section linking to polar.sh for funding the issue."


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request adds a new 'fund' label to the GitHub labels configuration, including a description and color code.

- **Chores**:
    - Added a new label 'fund' to the list of GitHub labels with a description linking to polar.sh for funding the issue.

<!-- Generated by sourcery-ai[bot]: end summary -->