### PR TITLE
chore: attest build provenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
         if: ${{ github.ref_name == 'main' || startsWith(github.ref_name, 'stable/') }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Attest build provenance
         uses: actions/attest-build-provenance@v1
         if: steps.release.outputs.released == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
     concurrency: release
     permissions:
       id-token: write
+      attestations: write
       contents: write
 
     steps:
@@ -88,6 +89,12 @@ jobs:
         if: ${{ github.ref_name == 'main' || startsWith(github.ref_name, 'stable/') }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Attest build build provenance
+        uses: actions/attest-build-provenance@v1
+        if: steps.release.outputs.released == 'true'
+        with:
+          subject-path: "dist/*"
+
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         if: steps.release.outputs.released == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
         if: ${{ github.ref_name == 'main' || startsWith(github.ref_name, 'stable/') }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Attest build build provenance
+      - name: Attest build provenance
         uses: actions/attest-build-provenance@v1
         if: steps.release.outputs.released == 'true'
         with:


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add a step in the CI workflow to attest build provenance when a release is made.

CI:
- Add step to attest build provenance using actions/attest-build-provenance@v1 in the CI workflow.

<!-- Generated by sourcery-ai[bot]: end summary -->