### PR TITLE
chore: ignore commits with unknown category in PSR

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,8 +58,9 @@ build_command = "pip install poetry && poetry build"
 
 [tool.semantic_release.changelog]
 exclude_commit_patterns = [
-    "chore*",
-    "ci*",
+    "chore.*",
+    "ci.*",
+    "Merge pull request .*",
 ]
 
 [tool.semantic_release.changelog.environment]

--- a/templates/CHANGELOG.md.j2
+++ b/templates/CHANGELOG.md.j2
@@ -5,7 +5,7 @@
 
 ## {{ version.as_tag() }} ({{ release.tagged_date.strftime("%Y-%m-%d") }})
 
-{%- for category, commits in release["elements"].items() %}
+{%- for category, commits in release["elements"].items() %}{% if category != "unknown" %}
 {# Category title: Breaking, Fix, Documentation #}
 ### {{ category | capitalize }}
 {# List actual changes in the category #}
@@ -13,7 +13,7 @@
 - {{ commit.descriptions[0] | capitalize }} ([`{{ commit.short_hash }}`]({{ commit.hexsha | commit_hash_url }}))
 {%- endfor %}{# for commit #}
 
-{%- endfor %}{# for category, commits #}
+{%- endif %}{% endfor %}{# for category, commits #}
 
 {%- endif %}{# if version.as_tag() #}
 


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Update the changelog generation template to exclude commits categorized as 'unknown' from being listed in the changelog.

Enhancements:
- Ignore commits with the 'unknown' category in the changelog generation template.

<!-- Generated by sourcery-ai[bot]: end summary -->