### PR TITLE
feat: drop support for Python 3.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.8"
           - "3.9"
           - "3.10"
           - "3.11"

--- a/poetry.lock
+++ b/poetry.lock
@@ -970,7 +970,6 @@ files = [
 [package.dependencies]
 markdown-it-py = ">=2.2.0"
 pygments = ">=2.13.0,<3.0.0"
-typing-extensions = {version = ">=4.0.0,<5.0", markers = "python_version < \"3.9\""}
 
 [package.extras]
 jupyter = ["ipywidgets (>=7.5.1,<9)"]
@@ -1692,5 +1691,5 @@ multidict = ">=4.0"
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.8"
-content-hash = "3211e4c83d17ef0e9fb52726c799f9b0317b93f53ae36759e3a80aee47a3d08d"
+python-versions = "^3.9"
+content-hash = "be63176fa39a4e31e59a64a8a7219b4c35c92db9c3ecf177c06d6f422e4436f8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ packages = [
 "Mastodon" = "https://fosstodon.org/@browniebroke"
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.9"
 httpx = ">=0.23.0"
 
 [tool.poetry.group.docs]
@@ -54,7 +54,7 @@ vcrpy = "^6.0.0"
 deezer-oauth-cli = "^1.0.0"
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py39"
 line-length = 120
 
 lint.select = [

--- a/src/deezer/pagination.py
+++ b/src/deezer/pagination.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Generator, Generic, TypeVar, overload
+from collections.abc import Generator
+from typing import Generic, TypeVar, overload
 from urllib.parse import parse_qs, urlparse
 
 import deezer

--- a/src/deezer/resources/playlist.py
+++ b/src/deezer/resources/playlist.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Iterable
+from collections.abc import Iterable
+from typing import TYPE_CHECKING
 
 from ..utils import gen_ids
 from .resource import Resource

--- a/src/deezer/utils.py
+++ b/src/deezer/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Generator, Iterable
+from collections.abc import Generator, Iterable
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from deezer import Resource


### PR DESCRIPTION
It reached EOL this month.

Committed via https://github.com/asottile/all-repos

## Summary by Sourcery

CI:
- Remove Python 3.8 from the CI testing matrix.