### PR TITLE
fix: don't forward parent when getting artist radio

### DIFF
--- a/src/deezer/resources/artist.py
+++ b/src/deezer/resources/artist.py
@@ -57,7 +57,8 @@ class Artist(Resource):
 
         :returns: list of :class:`Track <deezer.Track>` instances
         """
-        return self.get_relation("radio", **kwargs)
+        # radio returns tracks from different artists -> no fwd parent
+        return self.get_relation("radio", fwd_parent=False, **kwargs)
 
     def get_albums(self, **kwargs) -> PaginatedList[Album]:
         """

--- a/src/deezer/resources/resource.py
+++ b/src/deezer/resources/resource.py
@@ -61,6 +61,7 @@ class Resource:
         relation: str,
         resource_type: type[Resource] | None = None,  # type: ignore[valid-type]
         params: dict | None = None,
+        fwd_parent: bool = True,
     ):
         """
         Generic method to load the relation from any resource.
@@ -73,7 +74,7 @@ class Resource:
         return self.client.request(
             "GET",
             f"{self.type}/{self.id}/{relation}",
-            parent=self,
+            parent=self if fwd_parent else None,
             resource_type=resource_type,
             params=params,
         )

--- a/tests/resources/test_artist.py
+++ b/tests/resources/test_artist.py
@@ -40,6 +40,7 @@ class TestArtist:
         track = tracks[0]
         assert isinstance(track, deezer.Track)
         assert repr(track) == "<Track: One More Time>"
+        assert any(track_.artist.name != daft_punk.name for track_ in tracks)
 
     def test_get_related(self, daft_punk):
         related_artists = daft_punk.get_related()


### PR DESCRIPTION
Fixes #1210 

### Description of change

- Added a fwd_parent (bool) parameter in src/deezqer/resources/resource:Resource.get_relation. Default value to True
- Set the fwd_parent to false when calling src/deezer/resources/artist:Artist.get_radio
- Added assertion in tests/resources/test_artist.py:TestArtist.test_get_radio

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/browniebroke/deezer-python/blob/main/CONTRIBUTING.md).
- [x] This pull request links relevant issues as `Fixes #0000` (replace `0000` with the actual issue number)
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

## Summary by Sourcery

Fix the bug where the artist radio incorrectly forwards the parent artist by introducing a fwd_parent parameter in the get_relation method and setting it to false for artist radio. Update tests to ensure tracks are from different artists.

Bug Fixes:
- Fix the issue where the artist radio was incorrectly forwarding the parent artist by setting the fwd_parent parameter to false.

Tests:
- Add an assertion in the test_get_radio test case to verify that tracks returned are from different artists.