### PR TITLE
chore: add note about current unavailability of new app registration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,11 +95,11 @@ Ready to contribute? Here's how to set up `deezer-python` for local development.
 >
 > To obtain an **API token**, you first need to register your application at the [Deezer Developer Portal](https://developers.deezer.com/myapps). Unfortunately, **at the moment, it is not possible to register a new application via the Deezer Developer Portal.**
 >
-> The portal currently displays the message:  
+> The portal currently displays the message:
 > **"We're not accepting new application creation at this time. Please check again later."**
 >
 > It is not possible to obtain a token unless you have already registered your application and have both **APP_ID** and **APP_SECRET**.
- 
+
 If you want to work on a feature that requires authentication, you'll need to obtain an API token to perform authenticated requests. You can do so using the [`deezer-oauth-cli`](https://pypi.org/project/deezer-oauth-cli/) package. It's a development dependency, so if you ran `uv sync`, you should already have it.
 
 You'll need to have a dedicated app in the [Deezer developer portal](https://developers.deezer.com/myapps), create one with the following redirect URL after authentication: `http://localhost:8080/oauth/return`. Once created, grab the application ID and the secret key and call the CLI tool with them:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,6 +91,15 @@ Ready to contribute? Here's how to set up `deezer-python` for local development.
 
 ## Obtain an API token
 
+> **Important note**
+>
+> To obtain an **API token**, you first need to register your application at the [Deezer Developer Portal](https://developers.deezer.com/myapps). Unfortunately, **at the moment, it is not possible to register a new application via the Deezer Developer Portal.**
+>
+> The portal currently displays the message:  
+> **"We're not accepting new application creation at this time. Please check again later."**
+>
+> It is not possible to obtain a token unless you already registered your application and have both **APP_ID** and **APP_SECRET**.
+ 
 If you want to work on a feature that requires authentication, you'll need to obtain an API token to perform authenticated requests. You can do so using the [`deezer-oauth-cli`](https://pypi.org/project/deezer-oauth-cli/) package. It's a development dependency, so if you ran `uv sync`, you should already have it.
 
 You'll need to have a dedicated app in the [Deezer developer portal](https://developers.deezer.com/myapps), create one with the following redirect URL after authentication: `http://localhost:8080/oauth/return`. Once created, grab the application ID and the secret key and call the CLI tool with them:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,7 @@ Ready to contribute? Here's how to set up `deezer-python` for local development.
 > The portal currently displays the message:  
 > **"We're not accepting new application creation at this time. Please check again later."**
 >
-> It is not possible to obtain a token unless you already registered your application and have both **APP_ID** and **APP_SECRET**.
+> It is not possible to obtain a token unless you have already registered your application and have both **APP_ID** and **APP_SECRET**.
  
 If you want to work on a feature that requires authentication, you'll need to obtain an API token to perform authenticated requests. You can do so using the [`deezer-oauth-cli`](https://pypi.org/project/deezer-oauth-cli/) package. It's a development dependency, so if you ran `uv sync`, you should already have it.
 


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/browniebroke/deezer-python/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [ ] This pull request follows the [contributing guidelines](https://github.com/browniebroke/deezer-python/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000` (replace `0000` with the actual issue number)
- [ ] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `poetry run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->

## Summary by Sourcery

Documentation:
- Add notice that new application registration is currently unavailable in the Deezer Developer Portal and that only existing APP_ID and APP_SECRET can be used to obtain API tokens

Fix #1357