### PR TITLE
chore: update RTD config to latest convention

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,21 +1,21 @@
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
-# Required
 version: 2
 
-# Set the version of Python and other tools you might need
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.12"
-  commands:
-    - asdf plugin add uv
-    - asdf install uv latest
-    - asdf global uv latest
-    - uv sync --only-group docs --frozen
-    - uv run -m sphinx -T -b html -d docs/_build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html
+    python: "3.13"
+  jobs:
+    pre_create_environment:
+      - asdf plugin add uv
+      - asdf install uv latest
+      - asdf global uv latest
+    create_environment:
+      - uv venv "${READTHEDOCS_VIRTUALENV_PATH}"
+    install:
+      - UV_PROJECT_ENVIRONMENT="${READTHEDOCS_VIRTUALENV_PATH}" uv sync --frozen --no-dev --group docs
 
-# Build documentation in the docs directory with Sphinx
 sphinx:
   configuration: docs/conf.py


### PR DESCRIPTION
### Description of change

- Update RTD config following [latest recommendations](https://docs.readthedocs.com/platform/stable/build-customization.html#install-dependencies-with-uv) to avoid specifying the Sphinx command.
- Build to Ubuntu 24 and Python 3.13

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/browniebroke/deezer-python/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000` (replace `0000` with the actual issue number)
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".