### PR TITLE
chore: update PR template for prek

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -40,7 +40,7 @@
 - [ ] Documentation has been updated to reflect this change
 - [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".
 
-> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
+> - If the lint job is failing, try `prek run -a` for further information.
 > - If CI / test is failing, try `poetry run pytest` for further information.
 
 <!--


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos

## Summary by Sourcery

Documentation:
- Clarify PR template instructions by directing users to run `prek run -a` when the lint job fails instead of the old pre-commit.ci command.