### PR TITLE
chore: remove .gitpot.yml

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,8 +1,0 @@
-tasks:
-  - command: |
-      pip install uv
-      PIP_USER=false uv sync
-  - command: |
-      pip install pre-commit
-      pre-commit install
-      PIP_USER=false pre-commit install-hooks


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos

## Summary by Sourcery

Chores:
- Delete unused .gitpod.yml configuration file now that Gitpod setup is no longer required.