### PR TITLE
chore(deps): downgrade tiangolo/issue-manager action to v0.7.0

### DIFF
--- a/.github/workflows/issue-manager.yml
+++ b/.github/workflows/issue-manager.yml
@@ -18,7 +18,7 @@ jobs:
   issue-manager:
     runs-on: ubuntu-latest
     steps:
-      - uses: tiangolo/issue-manager@48bacd85fb842cc27efee25e834edb00aad8f263 # 0.8.0
+      - uses: tiangolo/issue-manager@8505bda3fd28623a64d93935cbe13fa23f14fd8b # 0.7.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config: >


### PR DESCRIPTION
Reverts browniebroke/deezer-python#1661

## Summary by Sourcery

CI:
- Update the issue-manager GitHub Actions workflow to use tiangolo/issue-manager v0.7.0 instead of v0.8.0.