### PR TITLE
feat: add support for Python 3.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
           - "3.12"
           - "3.13"
           - "3.14"
+          - "3.15"
         os:
           - ubuntu-latest
           - windows-latest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: 3.15",
   "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
@@ -97,7 +98,7 @@ lint.per-file-ignores."tests/**/*" = [
 lint.isort.known-first-party = [ "deezer" ]
 
 [tool.pyproject-fmt]
-max_supported_python = "3.14"
+max_supported_python = "3.15"
 
 [tool.pytest]
 addopts = [ "-v", "-Wdefault", "--cov=deezer" ]


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos

## Summary by Sourcery

Add Python 3.15 support across project configuration and CI matrix.

New Features:
- Declare compatibility with Python 3.15 in project metadata.

Build:
- Update tooling configuration to treat Python 3.15 as the maximum supported version.

CI:
- Extend CI test matrix to run against Python 3.15.