### PR TITLE
ci: fail lint job if prek fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,15 @@ jobs:
           ref: ${{ github.head_ref || github.ref }}
       - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
       - uses: j178/prek-action@4e14d07f9231acabce116ccfca13b13dd9755ece # v3.0.0
+        id: prek
         continue-on-error: true
       - uses: pre-commit-ci/lite-action@5d6cc0eb514c891a40562a58a8e71576c5c7fb43 # v1.1.0
+        if: always()
         with:
           msg: "chore: auto-fix from pre-commit hooks"
+      - name: Fail if hooks failed
+        if: steps.prek.outcome == 'failure'
+        run: exit 1
 
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos

## Summary by Sourcery

CI:
- Update lint workflow to record prek step outcome and explicitly fail the job if prek hooks fail, while always running the pre-commit lite action.