### PR TITLE
chore: remove long-lived GitHub PAT in labels workflow

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -10,8 +10,11 @@ on:
 jobs:
   labels:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
       - name: Sync config with Github
-        run: uvx labels -u ${{ github.repository_owner }} -t ${{ secrets.GH_PAT }} sync -f .github/labels.toml
+        run: uvx labels -u ${{ github.repository_owner }} -t ${{ secrets.GITHUB_TOKEN }} sync -f .github/labels.toml


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos

## Summary by Sourcery

Enhancements:
- Replace the long-lived GitHub personal access token used by the label synchronization workflow with the repository-provided token and grant the job the required least-privilege permissions.